### PR TITLE
add seq_map

### DIFF
--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -228,6 +228,11 @@ def seq(*parsers):
     return seq_parser
 
 
+def seq_map(*args):
+    (*parsers, fn) = args
+    return seq(*parsers).map(lambda values: fn(*values))
+
+
 # combinator syntax
 def generate(fn):
     if isinstance(fn, str):

--- a/test/test_parsy.py
+++ b/test/test_parsy.py
@@ -1,6 +1,6 @@
 import unittest
 
-from parsy import ParseError, digit, generate, letter, regex, string
+from parsy import ParseError, digit, generate, letter, regex, string, seq_map
 
 
 class TestParser(unittest.TestCase):
@@ -168,6 +168,11 @@ class TestParser(unittest.TestCase):
         self.assertRaises(ParseError, then_digit.parse, 'xyzwv1')
         self.assertRaises(ParseError, then_digit.parse, 'x1')
 
+    def test_seq_map(self):
+        d = digit.map(int)
+        add_three_digits = seq_map(d, d, d, lambda x, y, z: x + y + z)
+
+        self.assertEqual(add_three_digits.parse('234'), 9)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a function that's been super useful over in parsimmon, since it's very often that after sequencing parsers you want to combine them without having to unpack the list manually.