### PR TITLE
Feature.multiple expected

### DIFF
--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -161,7 +161,15 @@ class Parser(object):
         return self.times(n) + self.many()
 
     def desc(self, description):
-        return self | fail(description)
+        @Parser
+        def desc_parser(stream, index):
+            result = self(stream, index)
+            if result.status:
+                return result
+            else:
+                return Result.failure(index, description)
+
+        return desc_parser
 
     def mark(self):
         @generate

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -28,26 +28,37 @@ class ParseError(RuntimeError):
             return '<out of bounds index {!r}>'.format(self.index)
 
     def __str__(self):
-        return 'expected {} at {}'.format(self.expected, self.line_info())
+        expected_list = [repr(e) for e in self.expected]
+        expected_list.sort()
+
+        if len(expected_list) == 1:
+            return 'expected {} at {}'.format(expected_list[0], self.line_info())
+        else:
+            return 'expected one of {} at {}'.format(', '.join(expected_list), self.line_info())
 
 
 class Result(namedtuple('Result', 'status index value furthest expected')):
     @staticmethod
     def success(index, value):
-        return Result(True, index, value, -1, None)
+        return Result(True, index, value, -1, frozenset([]))
 
     @staticmethod
     def failure(index, expected):
-        return Result(False, -1, None, index, expected)
+        return Result(False, -1, None, index, frozenset([expected]))
 
     # collect the furthest failure from self and other
     def aggregate(self, other):
         if not other:
             return self
-        if self.furthest >= other.furthest:
-            return self
 
-        return Result(self.status, self.index, self.value, other.furthest, other.expected)
+        if self.furthest > other.furthest:
+            return self
+        elif self.furthest == other.furthest:
+            # if we both have the same failure index, we combine the expected messages.
+            return Result(self.status, self.index, self.value, self.furthest, self.expected | other.expected)
+        else:
+            return Result(self.status, self.index, self.value, other.furthest, other.expected)
+
 
 
 class Parser(object):

--- a/test/test_parsy.py
+++ b/test/test_parsy.py
@@ -1,6 +1,7 @@
 import unittest
 
 from parsy import ParseError, digit, generate, letter, regex, string
+from parsy import seq, alt
 
 
 class TestParser(unittest.TestCase):
@@ -83,9 +84,19 @@ class TestParser(unittest.TestCase):
 
         ex = err.exception
 
-        self.assertEqual(ex.expected, 'a thing')
+        self.assertEqual(ex.expected, frozenset(['a thing']))
         self.assertEqual(ex.stream, 'x')
         self.assertEqual(ex.index, 0)
+
+    def test_multiple_failures(self):
+        abc = string('a') | string('b') | string('c')
+
+        with self.assertRaises(ParseError) as err:
+            abc.parse('d')
+
+        ex = err.exception
+        self.assertEqual(ex.expected, frozenset(['a', 'b', 'c']))
+        self.assertEqual(str(ex), "expected one of 'a', 'b', 'c' at 0:0")
 
     def test_generate_backtracking(self):
         @generate


### PR DESCRIPTION
Two important error message improvements:

* collect *all* failures from the same point (since many languages have a common `alt`, we want to show *everything* that could have been there, not just the one that happened to be checked last)
* given the above, `.desc(...)` should hide all the expected messages from its parsing, since those are considered part of parsing the whole.