### PR TITLE
fix '|-operator' example in docs

### DIFF
--- a/docs/ref/methods_and_combinators.rst
+++ b/docs/ref/methods_and_combinators.rst
@@ -427,7 +427,7 @@ example:
    >>> ((string('AB') | string('A')) + string('C')).parse('ABC')
    'ABC'
    >>> ((string('AB') | string('A')) + string('C')).parse('AC')
-   'ABC'
+   'AC'
 
 .. _parser-lshift:
 


### PR DESCRIPTION
In `docs/ref/methods_and_combinators.rst`, correct the output of one of the examples.

For the example: `((string('AB') | string('A')) + string('C')).parse('AC')` the doc currently suggests that the output should be `'ABC'`, which is incorrect.

Python session:

```
>>> from parsy import string
>>> ((string('AB') | string('A')) + string('C')).parse('AC')
'AC'
```