### PR TITLE
Implement & operator for seq()

### DIFF
--- a/docs/ref/methods_and_combinators.rst
+++ b/docs/ref/methods_and_combinators.rst
@@ -429,6 +429,36 @@ example:
    >>> ((string('AB') | string('A')) + string('C')).parse('AC')
    'AC'
 
+.. _parser-and:
+
+``&`` operator
+--------------
+
+``parser & other_parser``
+
+Returns a parser that runs a sequence of parsers in order and combines their
+results in a list.
+
+.. code:: python
+
+   >>> parser = string('x') & string('y') & string('z')
+   >>> parser.parse('xyz')
+   ['x', 'y', 'z']
+
+Unlike :func:`seq`, this does not keep nested lists returned by intermediate
+parsers such as :func:`seq`or methods relying on :meth:`~Parser.times` which
+include :meth:`~Parser.many`, :meth:`~Parser.at_most`, :meth:`~Parser.at_least`,
+:meth:`~Parser.optional`, and :meth:`~Parser.sep_by`.
+
+.. code:: python
+
+   >>> parser = seq(seq(string('x'), string('y')), string('z'))
+   >>> parser.parse('xyz')
+   [['x', 'y'], 'z']
+   >>> parser = (string('x') & string('y')) & string('z')
+   >>> parser.parse('xyz')
+   ['x', 'y', 'z']
+
 .. _parser-lshift:
 
 ``<<`` operator

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -229,6 +229,13 @@ class Parser(object):
     def __or__(self, other):
         return alt(self, other)
 
+    def __and__(self, other):
+        def flatten(a, b):
+            l = lambda x: x if isinstance(x, list) else [x]
+            return l(a) + l(b)
+
+        return seq(self, other).combine(flatten)
+
     # haskelley operators, for fun #
 
     # >>

--- a/test/test_parsy.py
+++ b/test/test_parsy.py
@@ -241,6 +241,34 @@ class TestParser(unittest.TestCase):
 
         self.assertRaises(ParseError, parser.parse, '\\z')
 
+    def test_and(self):
+        breakpoint()
+        x, y, z = [string(c) for c in 'xyz']
+        xy = x & y
+        xyz = x & y & z
+        x_yz = x & (y & z)
+        xy_z = xy & z
+
+        self.assertEqual(xy.parse('xy'), ['x', 'y'])
+        self.assertEqual(xyz.parse('xyz'), ['x', 'y', 'z'])
+        self.assertEqual(x_yz.parse('xyz'), ['x', 'y', 'z'])
+        self.assertEqual(xy_z.parse('xyz'), ['x', 'y', 'z'])
+
+    def test_and_flatten(self):
+        seq_times = seq(string('x'), string('y') * 2)
+        and_times = string('x') & string('y') * 2
+
+        self.assertEqual(seq_times.parse('xyy'), ['x', ['y', 'y']])
+        self.assertEqual(and_times.parse('xyy'), ['x', 'y', 'y'])
+
+        seq_seq = seq(string('x'), seq(string('y'), string('z')))
+        and_seq = string('x') & seq(string('y'), string('z'))
+        and_and = string('x') & (string('y') & string('z'))
+
+        self.assertEqual(seq_seq.parse('xyz'), ['x', ['y', 'z']])
+        self.assertEqual(and_seq.parse('xyz'), ['x', 'y', 'z'])
+        self.assertEqual(and_and.parse('xyz'), ['x', 'y', 'z'])
+
     def test_many(self):
         letters = letter.many()
         self.assertEqual(letters.parse('x'), ['x'])


### PR DESCRIPTION
This is an attempt to implement `&` operator for `seq()` as suggested in #27. 

It's more tricky than I initially thought because `__and__()` can only parse a pair of parsers at a time so it's hard to keep nested structures intact, while `seq()` has no problem handling a long list of parsers at once for each nested level. That's why I had to introduce `flatten()` inside `&` to unroll nested lists, otherwise we'd end up with a deep nested list consists of pair of output. Now there's a catch that `&` does not behave exactly the same way as `seq()`.

At least it seems to serve my purpose, still I'm not confident if this works for other cases, so please take a look and let me know your opinion.