### PR TITLE
Added many_until(p, end) function

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,7 @@ History and release notes
 
 * Documentation improvements.
 * Added :func:`peek`
+* Added :func:`many_until`
 * Remove Python 3.3 support
 * Add Python 3.7 support
 

--- a/docs/ref/methods_and_combinators.rst
+++ b/docs/ref/methods_and_combinators.rst
@@ -578,12 +578,12 @@ Parser combinators
 
    .. code-block:: python
 
-      >>> many_until(string("a"), string("abc")).parse("aabc")
-      ['a', 'abc']
+      >>> many_until(string("a"), string("abc")).parse("aaabc")
+      ['a', 'a', 'abc']
 
    Note that even though ``string("a")`` and ``string("abc")`` overlap, ``end``
-   parser is tried first after each match of ``parser``. Otherwise the previous
-   exemaple would fail with ``['a', 'a', 'a', ParseError]``.
+   parser is tried first after each match of ``parser``. Otherwise the example
+   above would fail with ``['a', 'a', 'a', ParseError]``.
 
    .. code-block:: python
 

--- a/docs/ref/methods_and_combinators.rst
+++ b/docs/ref/methods_and_combinators.rst
@@ -571,6 +571,29 @@ Parser combinators
       For earlier versions, see :meth:`Parser.tag` for a way of labelling parsed
       components and producing dictionaries.
 
+.. function:: many_until(parser, end)
+
+   Creates a parser that expects :arg:`parser` 0 or more times until :arg:`end` is
+   found.
+
+   .. code-block:: python
+
+      >>> many_until(string("a"), string("abc")).parse("aabc")
+      ['a', 'abc']
+
+   Note that even though ``string("a")`` and ``string("abc")`` overlap, ``end``
+   parser is tried first after each match of ``parser``. Otherwise the previous
+   exemaple would fail with ``['a', 'a', 'a', ParseError]``.
+
+   .. code-block:: python
+
+      >>> comment = string("<!--") >> many_until(any_char, string("-->")).map(
+      ...     lambda elems: "".join(elems[:-1]))
+      >>> comment.parser("<!-- Hi! -->")
+      ' Hi! '
+
+   This ``comment`` parser doesn't allow nested comments, though. Nested comments
+   parsing require a recursive parser as described in :doc:`/ref/generating`.
 
 Other combinators
 =================

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -437,7 +437,28 @@ def peek(parser):
             return Result.success(index, result.value)
         else:
             return result
+
     return peek_parser
+
+
+def many_until(p, end):
+    @Parser
+    def many_until_parser(stream, index):
+        values = []
+        while True:
+            end_result = end(stream, index)
+            if end_result.status:
+                values.append(end_result.value)
+                return Result.success(end_result.index, values)
+            else:
+                result = p(stream, index)
+                if result.status:
+                    values.append(result.value)
+                    index = result.index
+                else:
+                    return result.aggregate(end_result)
+
+    return many_until_parser
 
 
 any_char = test_char(lambda c: True, "any character")

--- a/test/test_parsy.py
+++ b/test/test_parsy.py
@@ -11,7 +11,7 @@ from datetime import date
 
 from parsy import (
     ParseError, alt, any_char, char_from, decimal_digit, digit, from_enum, generate, index, letter, line_info,
-    line_info_at, match_item, peek, regex, seq, string, string_from
+    line_info_at, many_until, match_item, peek, regex, seq, string, string_from
 )
 from parsy import test_char as parsy_test_char  # to stop pytest thinking this function is a test
 from parsy import test_item as parsy_test_item  # to stop pytest thinking this function is a test
@@ -441,6 +441,17 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(ParseError) as err:
             peek(digit).parse("a")
         self.assertEqual(str(err.exception), "expected 'a digit' at 0:0")
+
+    def test_many_until(self):
+        p = many_until(string('a'), string("abc"))
+        self.assertEqual(p.parse("aaabc"), ["a", "a", "abc"])
+        self.assertEqual(p.parse("abc"), ["abc"])
+        with self.assertRaises(ParseError) as err:
+            p.parse("ababc")
+        self.assertEqual(str(err.exception), "expected one of 'a', 'abc' at 0:1")
+        with self.assertRaises(ParseError) as err:
+            p.parse("aaa")
+        self.assertEqual(str(err.exception), "expected one of 'a', 'abc' at 0:3")
 
     def test_any_char(self):
         self.assertEqual(any_char.parse("x"), "x")


### PR DESCRIPTION
We could improve this by adding `min=0`, `max=Inf` and `consume_end=True` kwargs. It's already useful as is, though.

I'm not sure about the name of this function, but I couldn't find a better name.