### PR TITLE
Autocompile `bytes` (not just `str`) to regex expression when passed in as `exp` argument to `regex`

### DIFF
--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -385,7 +385,7 @@ def string(s, transform=noop):
 
 
 def regex(exp, flags=0, group=0):
-    if isinstance(exp, str):
+    if isinstance(exp, (str, bytes)):
         exp = re.compile(exp, flags)
     if isinstance(group, (str, int)):
         group = (group,)

--- a/tests/test_parsy.py
+++ b/tests/test_parsy.py
@@ -41,13 +41,21 @@ class TestParser(unittest.TestCase):
 
         self.assertRaises(ParseError, parser.parse, 'dog')
 
-    def test_regex(self):
+    def test_regex_str(self):
         parser = regex(r'[0-9]')
 
         self.assertEqual(parser.parse('1'), '1')
         self.assertEqual(parser.parse('4'), '4')
 
         self.assertRaises(ParseError, parser.parse, 'x')
+
+    def test_regex_bytes(self):
+        parser = regex(rb'[0-9]')
+
+        self.assertEqual(parser.parse(b'1'), b'1')
+        self.assertEqual(parser.parse(b'4'), b'4')
+
+        self.assertRaises(ParseError, parser.parse, b'x')
 
     def test_regex_compiled(self):
         parser = regex(re.compile(r'[0-9]'))


### PR DESCRIPTION
The `regex` function will call `re.compile` on the `exp` argument if it's a `str`, but `bytes` is also a valid data type in this context. Extend the type check from `isinstance(exp, str)` to `isinstance(exp, (str, bytes))`.

Add a test for using `bytes` with `regex`.

Also make the automated testing use a local import rather than a global import. The tests would fail because it would pick up the system-wide module rather than the local one in the repository.