### PR TITLE
support bytes in `test_item` and `char_from`

### DIFF
--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -405,7 +405,12 @@ def test_item(func, description):
     @Parser
     def test_item_parser(stream, index):
         if index < len(stream):
-            item = stream[index]
+            if isinstance(stream, bytes):
+                # Subscripting bytes with `[index]` instead of
+                # `[index:index + 1]` returns an int
+                item = stream[index:index + 1]
+            else:
+                item = stream[index]
             if func(item):
                 return Result.success(index + 1, item)
         return Result.failure(index, description)
@@ -430,7 +435,10 @@ def string_from(*strings, transform=noop):
 
 
 def char_from(string):
-    return test_char(lambda c: c in string, "[" + string + "]")
+    if isinstance(string, bytes):
+        return test_char(lambda c: c in string, b"[" + string + b"]")
+    else:
+        return test_char(lambda c: c in string, "[" + string + "]")
 
 
 def peek(parser):

--- a/tests/test_parsy.py
+++ b/tests/test_parsy.py
@@ -438,7 +438,7 @@ class TestParser(unittest.TestCase):
         ex = err.exception
         self.assertEqual(str(ex), """expected 'ascii character' at 0:0""")
 
-    def test_char_from(self):
+    def test_char_from_str(self):
         ab = char_from("ab")
         self.assertEqual(ab.parse("a"), "a")
         self.assertEqual(ab.parse("b"), "b")
@@ -448,6 +448,17 @@ class TestParser(unittest.TestCase):
 
         ex = err.exception
         self.assertEqual(str(ex), """expected '[ab]' at 0:0""")
+
+    def test_char_from_bytes(self):
+        ab = char_from(b"ab")
+        self.assertEqual(ab.parse(b"a"), b"a")
+        self.assertEqual(ab.parse(b"b"), b"b")
+
+        with self.assertRaises(ParseError) as err:
+            ab.parse(b'x')
+
+        ex = err.exception
+        self.assertEqual(str(ex), """expected b'[ab]' at 0""")
 
     def test_string_from(self):
         titles = string_from("Mr", "Mr.", "Mrs", "Mrs.")


### PR DESCRIPTION
Two more minor changes to support parsing bytes. I think this should be everything.