### PR TITLE
Added forward_declaration

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -12,6 +12,7 @@ History and release notes
   <https://github.com/camerondm9>`_.
 * Support ``bytes`` with :func:`regex` as well as ``str`` - thanks `@quack4
   <https://github.com/quack4>`_.
+* Added :class:`forward_declaration`.
 
 
 1.3.0 - 2019-08-03

--- a/docs/ref/generating.rst
+++ b/docs/ref/generating.rst
@@ -105,13 +105,15 @@ There are also more complex examples in the :ref:`tutorial
 <using-previous-values>` of using the ``generate`` decorator to create parsers
 where there is logic that is conditional upon earlier parsed values.
 
+.. _recursive-definitions-with-generate:
+
 Implementing recursive definitions
 ----------------------------------
 
 A fourth examples shows how you can use this syntax for grammars that you would
 like to define recursively (or mutually recursively).
 
-Say we want to be able to pass an s-expression like syntax which uses
+Say we want to be able to parse an s-expression like syntax which uses
 parenthesis for grouping items into a tree structure, like the following::
 
      (0 1 (2 3) (4 5 6) 7 8)
@@ -126,6 +128,9 @@ A naive approach would be:
 
 The problem is that the second line will get a ``NameError`` because ``expr`` is
 not defined yet.
+
+One way to solve this is to use :ref:`forward-declarations`. But another uses
+``@generate``.
 
 Using the ``@generate`` syntax will introduce a level of laziness in resolving
 ``expr`` that allows things to work:

--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -477,3 +477,24 @@ def from_enum(enum_cls, transform=noop):
                    reverse=True)
     return alt(*[string(value, transform=transform).result(enum_item)
                  for value, enum_item in items])
+
+
+class forward_declaration(Parser):
+    """
+    An empty parser that can be used as a forward declaration,
+    especially for parsers that need to be defined recursively.
+
+    You must use `.become(parser)` before using.
+    """
+    def __init__(self):
+        pass
+
+    def _raise_error(self, *args, **kwargs):
+        raise ValueError("You must use 'become' before attempting to call `parse` or `parse_partial`")
+
+    parse = _raise_error
+    parse_partial = _raise_error
+
+    def become(self, other):
+        self.__dict__ = other.__dict__
+        self.__class__ = other.__class__

--- a/tests/requirements-tests.txt
+++ b/tests/requirements-tests.txt
@@ -1,3 +1,4 @@
 pytest==6.0.1
 pytest-cov==2.10.1
 coverage==5.2.1
+more-itertools<8.6;python_version<"3.6"


### PR DESCRIPTION
This provides a simple mechanism to avoid problems with recursive grammars, without needing to use/abuse `@generate` syntax for that purpose. Examples in the docs added.