### PR TITLE
Track line and column data incrementally when parsing strings

### DIFF
--- a/tests/test_parsy.py
+++ b/tests/test_parsy.py
@@ -7,6 +7,7 @@ from datetime import date
 
 from parsy import (
     ParseError,
+    Position,
     alt,
     any_char,
     char_from,
@@ -18,7 +19,6 @@ from parsy import (
     index,
     letter,
     line_info,
-    line_info_at,
     match_item,
     peek,
     regex,
@@ -225,7 +225,7 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(ex.expected, frozenset(["a thing"]))
         self.assertEqual(ex.stream, "x")
-        self.assertEqual(ex.index, 0)
+        self.assertEqual(ex.index, Position(0, 0, 0))
 
     def test_generate_default_desc(self):
         # We shouldn't give a default desc, the messages from the internal
@@ -242,7 +242,7 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(ex.expected, frozenset(["b"]))
         self.assertEqual(ex.stream, "ax")
-        self.assertEqual(ex.index, 1)
+        self.assertEqual(ex.index, Position(1, 0, 1))
 
         self.assertIn("expected 'b' at 0:1", str(ex))
 
@@ -345,7 +345,6 @@ class TestParser(unittest.TestCase):
         self.assertRaises(ParseError, ab.at_most(2).parse, "ababab")
 
     def test_until(self):
-
         until = string("s").until(string("x"))
 
         s = "ssssx"
@@ -367,7 +366,6 @@ class TestParser(unittest.TestCase):
         self.assertEqual(until.parse_partial("xxxx"), ([], "xxxx"))
 
     def test_until_with_consume_other(self):
-
         until = string("s").until(string("x"), consume_other=True)
 
         self.assertEqual(until.parse("ssssx"), 4 * ["s"] + ["x"])
@@ -379,7 +377,6 @@ class TestParser(unittest.TestCase):
         self.assertRaises(ParseError, until.parse, "xssssxy")
 
     def test_until_with_min(self):
-
         until = string("s").until(string("x"), min=3)
 
         self.assertEqual(until.parse_partial("sssx"), (3 * ["s"], "x"))
@@ -388,7 +385,6 @@ class TestParser(unittest.TestCase):
         self.assertRaises(ParseError, until.parse_partial, "ssx")
 
     def test_until_with_max(self):
-
         # until with max
         until = string("s").until(string("x"), max=3)
 
@@ -398,7 +394,6 @@ class TestParser(unittest.TestCase):
         self.assertRaises(ParseError, until.parse_partial, "ssssx")
 
     def test_until_with_min_max(self):
-
         until = string("s").until(string("x"), min=3, max=5)
 
         self.assertEqual(until.parse_partial("sssx"), (3 * ["s"], "x"))
@@ -647,7 +642,7 @@ class TestParserTokens(unittest.TestCase):
         ex = err.exception
         self.assertEqual(str(ex), "expected one of 'EOF', 'START/STOP' at 1")
         self.assertEqual(ex.expected, {"EOF", "START/STOP"})
-        self.assertEqual(ex.index, 1)
+        self.assertEqual(ex.index, Position(1, -1, -1))
 
     def test_match_item(self):
         self.assertEqual(match_item(self.START).parse([self.START]), self.START)
@@ -673,17 +668,6 @@ class TestParserTokens(unittest.TestCase):
             return (l, i)
 
         self.assertEqual(foo.many().parse(["A", "B"]), [("A", 0), ("B", 1)])
-
-
-class TestUtils(unittest.TestCase):
-    def test_line_info_at(self):
-        text = "abc\ndef"
-        self.assertEqual(line_info_at(text, 0), (0, 0))
-        self.assertEqual(line_info_at(text, 2), (0, 2))
-        self.assertEqual(line_info_at(text, 3), (0, 3))
-        self.assertEqual(line_info_at(text, 4), (1, 0))
-        self.assertEqual(line_info_at(text, 7), (1, 3))
-        self.assertRaises(ValueError, lambda: line_info_at(text, 8))
 
 
 class TestForwardDeclaration(unittest.TestCase):


### PR DESCRIPTION
This PR replaces the integer `index` into a stream with a triple of integers representing `offset`, `line` and `column` information. 

`offset` is what `index` originally was: how many individual elements of the stream have been consumed. 

When parser input is a string `line` and `column` are updated incrementally with each character of the input string. 

When parser input is not a string `line` and `column` are both set to `-1` and ignored. 

This adds a huge speedup on large inputs to parsers which make frequent use of the `line_info` parser. For reference, using the example JSON parser updated to track line/col data on each node, a 100k line JSON file goes from taking ~210 seconds to ~7 seconds on my machine. We've gone from quadratic time position tracking to linear time position tracking.

I added no new tests, since this PR does add a new feature, only changes the implementation of an existing one. I'm happy to add more tests if needed though.