### PR TITLE
Fix pytest, since we have `src/` layer

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 python_files = examples/*.py tests/*.py
+pythonpath = src/


### PR DESCRIPTION
When the package is not installed, pytest can't find the python module, since it is behind `src/` directory.

I guess no one noticed because they were installing the package before running the tests.