### PR TITLE
Add support for PEP 561 and static type checkers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include tox.ini
 include pytest.ini
 include conftest.py
 include .editorconfig
+include src/parsy/py.parsed
 recursive-include docs *.bat
 recursive-include docs *.txt
 recursive-include docs *.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,9 @@ python_requires = >=3.7
 packages = find:
 package_dir = =src
 
+[options.package_data]
+parsy = py.typed
+
 [options.packages.find]
 where = src
 

--- a/src/parsy/py.parsed
+++ b/src/parsy/py.parsed
@@ -1,0 +1,1 @@
+# Support for PEP 561


### PR DESCRIPTION
Using `parsy` on a project that uses `mypy` currently leads to:

```
error: Skipping analyzing "parsy": module is installed, but missing library stubs or py.typed marker  [import]
```

This PR introduces a `py.typed` file that specifies that parsy supports type checking. See [PEP 561](https://peps.python.org/pep-0561/) for additional context.