### PR TITLE
Add source names (via new `Stream` and `SourceSpan` classes) and `.span()` combinator (take 2)

### DIFF
--- a/docs/ref/methods_and_combinators.rst
+++ b/docs/ref/methods_and_combinators.rst
@@ -23,7 +23,7 @@ can be used and manipulated as below.
    The following methods are for actually **using** the parsers that you have
    created:
 
-   .. method:: parse(string_or_list)
+   .. method:: parse(string_or_list[, source=None])
 
       Attempts to parse the given string (or list). If the parse is successful
       and consumes the entire string, the result is returned - otherwise, a
@@ -36,7 +36,11 @@ can be used and manipulated as below.
       library will work with tokens just as well. See :doc:`/howto/lexing` for
       more information.
 
-   .. method:: parse_partial(string_or_list)
+      When a non-None ``source`` is given, this name is reported automatically
+      in parse errors. Typically, this is the file path or URL where the data
+      to parse originates from.
+
+   .. method:: parse_partial(string_or_list[, source=None])
 
       Similar to ``parse``, except that it does not require the entire
       string (or list) to be consumed. Returns a tuple of
@@ -401,6 +405,20 @@ can be used and manipulated as below.
       </howto/lexing/>` and want subsequent parsing of the token stream to be
       able to report original positions in error messages etc.
 
+   .. method:: span()
+
+      Returns a parser that augments the initial parser's result with a :class:`SourceSpan`
+      containing information about where that parser started and stopped within the
+      source data. The new value is a tuple:
+
+      .. code:: python
+
+         (source_span, original_value)
+
+      This enables reporting of custom errors involving source locations, such as when
+      using parsy as a :doc:`lexer</howto/lexing/>` or when building a syntax tree that will be
+      further analyzed.
+
 .. _operators:
 
 Parser operators
@@ -594,3 +612,26 @@ Parsy does not try to include every possible combinator - there is no reason why
 you cannot create your own for your needs using the built-in combinators and
 primitives. If you find something that is very generic and would be very useful
 to have as a built-in, please :doc:`submit </contributing>` as a PR!
+
+Auxiliary data structures
+=========================
+
+.. class:: SourceSpan
+
+   Identifies a span of material from the data being parsed by its start row and column and its end
+   row and column. If the data stream was equipped with a source, that value is also available in
+   this object.
+
+   .. attribute:: start
+
+      The starting position of this span as a tuple (row, col)
+
+   .. attribute:: end
+
+      The stopping position of this span as a tuple (row, col)
+
+   .. attribute:: source
+
+      The name of the source the data was parsed from. This is the same value
+      that was passed to :meth:`Parser.parse` or :meth:`Parser.parse_partial`,
+      or `None` if no value was given.

--- a/tests/test_parsy.py
+++ b/tests/test_parsy.py
@@ -20,6 +20,7 @@ from parsy import (
     letter,
     line_info,
     line_info_at,
+    make_stream,
     match_item,
     peek,
     regex,
@@ -619,6 +620,18 @@ class TestParser(unittest.TestCase):
             ],
         )
 
+        source = "aaaaa"
+        self.assertEqual(
+            foo.many().parse("AB\nCD", source=source),
+            [
+                ("A", (0, 0, source)),
+                ("B", (0, 1, source)),
+                ("\n", (0, 2, source)),
+                ("C", (1, 0, source)),
+                ("D", (1, 1, source)),
+            ],
+        )
+
     def test_should_fail(self):
         not_a_digit = digit.should_fail("not a digit") >> regex(r".*")
 
@@ -713,14 +726,24 @@ class TestParserTokens(unittest.TestCase):
 
 class TestUtils(unittest.TestCase):
     def test_line_info_at(self):
+
         text = "abc\ndef"
         self.assertEqual(line_info_at(text, 0), (0, 0))
         self.assertEqual(line_info_at(text, 2), (0, 2))
         self.assertEqual(line_info_at(text, 3), (0, 3))
         self.assertEqual(line_info_at(text, 4), (1, 0))
         self.assertEqual(line_info_at(text, 7), (1, 3))
+
         self.assertRaises(ValueError, lambda: line_info_at(text, 8))
 
+        text = make_stream("abc\ndef", source="aaaa")
+        self.assertEqual(line_info_at(text, 0), (0, 0, "aaaa"))
+        self.assertEqual(line_info_at(text, 2), (0, 2, "aaaa"))
+        self.assertEqual(line_info_at(text, 3), (0, 3, "aaaa"))
+        self.assertEqual(line_info_at(text, 4), (1, 0, "aaaa"))
+        self.assertEqual(line_info_at(text, 7), (1, 3, "aaaa"))
+
+        self.assertRaises(ValueError, lambda: line_info_at(text, 8))
 
 
 class TestForwardDeclaration(unittest.TestCase):


### PR DESCRIPTION
Following up from #83, here's a new PR:

* without any CI adjustments
* using `str` and `bytes` subclasses equipped with a `source` attribute, wrapping the user's input only when a `source` is provided to `.parse()` or `.parse_partial()`.

The test suite is virtually unchanged this time around. I took care to keep everything as backwards compatible as possible, including keeping `line_info` returning a 2-tuple when no source is given.