### PR TITLE
fix(desc): aggregate original failure result to preserve error info

### DIFF
--- a/src/parsy/__init__.py
+++ b/src/parsy/__init__.py
@@ -332,7 +332,7 @@ class Parser:
             if result.status:
                 return result
             else:
-                return Result.failure(index, description)
+                return Result.failure(index, description).aggregate(result)
 
         return desc_parser
 

--- a/tests/test_parsy.py
+++ b/tests/test_parsy.py
@@ -229,7 +229,7 @@ class TestParser(unittest.TestCase):
 
         ex = err.exception
 
-        self.assertEqual(ex.expected, frozenset(["a thing"]))
+        self.assertEqual(ex.expected, frozenset(["t", "a thing"]))
         self.assertEqual(ex.stream, "x")
         self.assertEqual(ex.index, 0)
 


### PR DESCRIPTION
## Description

`Parser.desc()` discards the original parser's failure position and expected messages, replacing them with just the description string. This causes incorrect error positions when the original parser consumed input before failing -- the error always shows the start position of `desc_parser` instead of the actual failure position.

Fix: aggregate the original failure result into the new desc failure, so the furthest failure position and combined expected messages are preserved.

## Example

Before:
```python
parser = (string('hello') >> string(' world')).desc('hello world')
parser.parse('hello!!!')
# ERROR: expected 'hello world' at 0:0   ← WRONG position
```

After:
```python
parser.parse('hello!!!')
# ERROR: expected ' world' at 0:5         ← CORRECT position after 'hello'
```

## Test

Updated `test_generate_desc` to expect the combined expected set, which now correctly includes both the original parser's expected value (`'t'`) and the description (`'a thing'`).

```
86 passed, 2 skipped in 0.03s
```

## AI Disclosure

This fix was developed with assistance from an AI coding tool (Claude Code) under the direction of the PR author.